### PR TITLE
Fixing #351

### DIFF
--- a/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
+++ b/src/UnityExtension/Assets/Editor/GitHub.Unity/Misc/Utility.cs
@@ -32,7 +32,7 @@ namespace GitHub.Unity
 
         static StreamExtensions()
         {
-            var t = typeof(Texture2D).Assembly.GetType("UnityEngine.ImageConversion", false, false);
+            var t = Assembly.Load("UnityEngine.dll").GetType("UnityEngine.ImageConversion", false, false);
             if (t != null)
             {
                 // looking for ImageConversion.LoadImage(this Texture2D tex, byte[] data)


### PR DESCRIPTION
Applying shiena's code fixes #351.


### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

> the problem is that ImageConversion got moved out to a separate DLL, which means using Texture2D as a DLL location base no longer works. Worse, it got moved to its own assembly - literally a DLL which only contains this class, which means there is no type we can use to get at its location. So, sigh, we'll need to add yet another codepath to the StreamExtensions code to reference the UnityEngine.ImageConversionModule.dll dll and get the ImageConversion type.

Apparently, you don't need to, and that's all you have to do. 

### Benefits

<!-- What benefits will be realized by the code change? -->
Solving #351